### PR TITLE
Add some fixes for micropython on ESP8266 on NODEMCU

### DIFF
--- a/hcsr04.py
+++ b/hcsr04.py
@@ -24,7 +24,7 @@ class HCSR04:
         self.echo_timeout_us = echo_timeout_us
         # Init trigger pin (out)
         self.trigger = Pin(trigger_pin, mode=Pin.OUT, pull=None)
-        self.trigger.low()
+        self.trigger.value(0)
 
         # Init echo pin (in)
         self.echo = Pin(echo_pin, mode=Pin.IN, pull=None)
@@ -34,12 +34,12 @@ class HCSR04:
         Send the pulse to trigger and listen on echo pin.
         We use the method `machine.time_pulse_us()` to get the microseconds until the echo is received.
         """
-        self.trigger.low() # Stabilize the sensor
+        self.trigger.value(0) # Stabilize the sensor
         time.sleep_us(5)
-        self.trigger.high()
+        self.trigger.value(1)
         # Send a 10us pulse.
         time.sleep_us(10)
-        self.trigger.low()
+        self.trigger.value(0)
         try:
             pulse_time = machine.time_pulse_us(self.echo, 1, self.echo_timeout_us)
             return pulse_time

--- a/hcsr04.py
+++ b/hcsr04.py
@@ -13,9 +13,8 @@ class HCSR04:
     The timeouts received listening to echo pin are converted to OSError('Out of range')
 
     """
-    # Timeout is based in chip range limit (400cm)
-    TIMEOUT_US = 500*2*30
-    def __init__(self, trigger_pin, echo_pin, echo_timeout_us=HCSR04.TIMEOUT_US):
+    # echo_timeout_us is based in chip range limit (400cm)
+    def __init__(self, trigger_pin, echo_pin, echo_timeout_us=500*2*30):
         """
         trigger_pin: Output pin to send pulses
         echo_pin: Readonly pin to measure the distance. The pin should be protected with 1k resistor


### PR DESCRIPTION
Hello,

I'm using the library on an ESP8266 built by NODEMCU.

It works fine except from that machine.Pin.low() and machine.Pin.high() and in my version of micropython the default value from HCSR04.TIMEOUT_US isn't defined as described in 860d453.