### PR TITLE
Air temperature support

### DIFF
--- a/hcsr04.py
+++ b/hcsr04.py
@@ -1,7 +1,7 @@
 import machine, time
 from math import sqrt
 
-__version__ = '0.2.0'
+__version__ = '1.0.0'
 __author__ = 'Roberto Sánchez'
 __license__ = "Apache License 2.0. https://www.apache.org/licenses/LICENSE-2.0"
 


### PR DESCRIPTION
I added the possibility to set the air temperature. We know the distance depends by the speed of sound. This one varies as the air temperature varies.

As an example if we consider the speed of sound at the temperature of 20°C, it is ~343m/s. Distance is calculated moltipling speed * time of return of the signal sent from the sensor. So if we suppose as time of return 0.01s we have:
> temperature = 10°C
> time = 0.01s
> speed = 337.38 m/s (at 10°C)
> distance = 337.38m/s * 0.01s ~ 3.37m

whereas, ignoring the variation of the speed as varies the temperature of the air, we have:
> temperature = 10°C (we don't need this)
> time = 0.01s
> speed = 343.28 m/s (at 20°C)
> distance = 343.28 m/s * 0.01s ~ 3.43m

so we have a 6 cm error, which in some cases could be considerable.

Thank you for your attention and for your work.