### PR TITLE
fix: time_pulse_us timeout handling

### DIFF
--- a/hcsr04.py
+++ b/hcsr04.py
@@ -42,6 +42,12 @@ class HCSR04:
         self.trigger.value(0)
         try:
             pulse_time = machine.time_pulse_us(self.echo, 1, self.echo_timeout_us)
+            # time_pulse_us returns -2 if there was timeout waiting for condition; and -1 if there was timeout during the main measurement. It DOES NOT raise an exception
+            # ...as of MicroPython 1.17: http://docs.micropython.org/en/v1.17/library/machine.html#machine.time_pulse_us
+            if pulse_time < 0:
+                MAX_RANGE_IN_CM = const(500) # it's really ~400 but I've read people say they see it working up to ~460
+                pulse_time = int(MAX_RANGE_IN_CM * 29.1) # 1cm each 29.1us
+                print("pulse time adjusted to:" + str(pulse_time))
             return pulse_time
         except OSError as ex:
             if ex.args[0] == 110: # 110 = ETIMEDOUT

--- a/hcsr04.py
+++ b/hcsr04.py
@@ -47,7 +47,6 @@ class HCSR04:
             if pulse_time < 0:
                 MAX_RANGE_IN_CM = const(500) # it's really ~400 but I've read people say they see it working up to ~460
                 pulse_time = int(MAX_RANGE_IN_CM * 29.1) # 1cm each 29.1us
-                print("pulse time adjusted to:" + str(pulse_time))
             return pulse_time
         except OSError as ex:
             if ex.args[0] == 110: # 110 = ETIMEDOUT


### PR DESCRIPTION
Current versions of MicroPython's `time_pulse_us` no longer raise exceptions on timeouts and instead return negative values: http://docs.micropython.org/en/v1.17/library/machine.html#machine.time_pulse_us
I noticed earlier versions in the docs (e.g. 1.9) did throw this exception. What's here worked for me in my testing, but if you want something else cleaned up or to take a different approach just let me know.